### PR TITLE
consider the insetForSection for estimating size

### DIFF
--- a/IVCollectionKit/Source/CollectionSection.swift
+++ b/IVCollectionKit/Source/CollectionSection.swift
@@ -81,7 +81,9 @@ open class CollectionSection : AbstractCollectionSection {
     }
     
     open func sizeForItem(at indexPath: IndexPath, boundingSize: CGSize) -> CGSize {
-        return items[indexPath.item].estimatedSize(boundingSize: boundingSize)
+        let sizeWithInsets = CGSize(width: boundingSize.width - insetForSection.left - insetForSection.right,
+                                    height: boundingSize.height - insetForSection.top - insetForSection.bottom)
+        return items[indexPath.item].estimatedSize(boundingSize: sizeWithInsets)
     }
     
     open func itemAdjustsWidth(at index: Int) -> Bool {


### PR DESCRIPTION
Bugs raised when `insetForSection` is specified but `boundingSize` at `estimatedSize(boundingSize:)` is wrong so it leads to incorrect size estimation.